### PR TITLE
LightSourcePresetを追加

### DIFF
--- a/g3i_camera_initializer/include/g3i_camera_initializer/camera_initializer.h
+++ b/g3i_camera_initializer/include/g3i_camera_initializer/camera_initializer.h
@@ -21,7 +21,7 @@ private:
 
   bool startup_grabbing_ = false;
   int max_transfer_size_ = 4194304;
-  int light_source_preset_ = 5;
+  int light_source_preset_ = 6;
 
   void initializeSetting();
   void initializeStartupGrabbing();

--- a/g3i_camera_initializer/include/g3i_camera_initializer/camera_initializer.h
+++ b/g3i_camera_initializer/include/g3i_camera_initializer/camera_initializer.h
@@ -17,12 +17,15 @@ private:
   std::shared_ptr<ros::NodeHandle> nh_;
   ros::ServiceClient stop_grabbing_client_;
   ros::ServiceClient max_transfer_size_client_;
+  ros::ServiceClient light_source_preset_client_;
 
   bool startup_grabbing_ = false;
   int max_transfer_size_ = 4194304;
+  int light_source_preset_ = 5;
 
   void initializeSetting();
   void initializeStartupGrabbing();
   void initializeMaxTransferSize();
+  void initializeLightSourcePreset();
 };
 } // namespace g3i_camera_initializer

--- a/g3i_camera_initializer/src/g3i_camera_initializer_node.cpp
+++ b/g3i_camera_initializer/src/g3i_camera_initializer_node.cpp
@@ -18,14 +18,19 @@ void CameraInitializer::initNode(std::shared_ptr<ros::NodeHandle> nh)
     "pylon_camera_node/stop_grabbing");
   this->max_transfer_size_client_ = this->nh_->serviceClient<camera_control_msgs::SetIntegerValue>(
     "pylon_camera_node/set_max_transfer_size");
+  this->light_source_preset_client_ = this->nh_->serviceClient<camera_control_msgs::SetIntegerValue>(
+    "pylon_camera_node/set_light_source_preset");
 
   this->nh_->getParam(
     "/g3i_camera_initializer_node/startup_grabbing", startup_grabbing_);
   this->nh_->getParam(
     "/g3i_camera_initializer_node/max_transfer_size", max_transfer_size_);
+  this->nh_->getParam(
+    "/g3i_camera_initializer_node/light_source_preset", light_source_preset_);
 
   ROS_INFO("[g3i_camera_initializer] startup_grabbing: %d", startup_grabbing_);
   ROS_INFO("[g3i_camera_initializer] max_transfer_size: %d", max_transfer_size_);
+  ROS_INFO("[g3i_camera_initializer] light_source_preset: %d", light_source_preset_);
 
   initializeSetting();
 }
@@ -35,6 +40,7 @@ void CameraInitializer::initializeSetting()
 {
   // NOTE:max_transfer_sizeを変更すると自動でカメラオンになってしまう
   initializeMaxTransferSize();
+  initializeLightSourcePreset();
   initializeStartupGrabbing();
 }
 
@@ -69,6 +75,20 @@ void CameraInitializer::initializeMaxTransferSize()
   } else {
     ROS_ERROR("[g3i_camera_initializer] Failed to set max_transfer_size.");
   }
+}
 
+/// @brief LightSourcePresetの設定(明るさ)
+void CameraInitializer::initializeLightSourcePreset()
+{
+  ros::service::waitForService("/pylon_camera_node/set_light_source_preset");
+
+  camera_control_msgs::SetIntegerValue integer_srv_;
+  integer_srv_.request.value = light_source_preset_;
+  // TODO:エラー番号を付与する
+  if (light_source_preset_client_.call(integer_srv_)) {
+    ROS_INFO("[g3i_camera_initializer] Successed to set light_source_preset.");
+  } else {
+    ROS_ERROR("[g3i_camera_initializer] Failed to set light_source_preset.");
+  }
 }
 }

--- a/pylon_camera/config/default.yaml
+++ b/pylon_camera/config/default.yaml
@@ -7,6 +7,9 @@ startup_grabbing: false
 # 最大転送サイズ
 max_transfer_size: 1048576
 
+# Light source preset
+light_source_preset: 5  # Microscope LED 6500K
+
 #  The DeviceUserID of the camera. If empty, the first camera found in the
 #  device list will be used
 device_user_id: ""

--- a/pylon_camera/config/default.yaml
+++ b/pylon_camera/config/default.yaml
@@ -8,7 +8,7 @@ startup_grabbing: false
 max_transfer_size: 1048576
 
 # Light source preset
-light_source_preset: 5  # Microscope LED 6500K
+light_source_preset: 6  # Microscope LED 6500K
 
 #  The DeviceUserID of the camera. If empty, the first camera found in the
 #  device list will be used

--- a/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -2498,6 +2498,18 @@ std::string PylonCameraImpl<CameraTraitT>::setLightSourcePreset(const int& mode)
             {
                 cam_->LightSourcePreset.SetValue(LightSourcePresetEnums::LightSourcePreset_Tungsten2800K);
             } 
+            else if (mode == 4)
+            {
+                cam_->LightSourcePreset.SetValue(LightSourcePresetEnums::LightSourcePreset_MicroscopeLED4500K);
+            } 
+            else if (mode == 5)
+            {
+                cam_->LightSourcePreset.SetValue(LightSourcePresetEnums::LightSourcePreset_MicroscopeLED5500K);
+            } 
+            else if (mode == 6)
+            {
+                cam_->LightSourcePreset.SetValue(LightSourcePresetEnums::LightSourcePreset_MicroscopeLED6000K);
+            } 
             else 
             {
                 return "Error: unknown value";
@@ -2557,6 +2569,18 @@ int PylonCameraImpl<CameraTraitT>::getLightSourcePreset()
             {
                 return 3; // Tungsten2800K
             } 
+            else if (cam_->LightSourcePreset.GetValue() == LightSourcePresetEnums::LightSourcePreset_MicroscopeLED4500K)
+            {
+                return 4; // MicroscopeLED4500K
+            } 
+            else if (cam_->LightSourcePreset.GetValue() == LightSourcePresetEnums::LightSourcePreset_MicroscopeLED5500K)
+            {
+                return 5; // MicroscopeLED5500K
+            } 
+            else if (cam_->LightSourcePreset.GetValue() == LightSourcePresetEnums::LightSourcePreset_MicroscopeLED6000K)
+            {
+                return 6; // MicroscopeLED6000K
+            }  
             else 
             {
                 return -3; // Unkonwn
@@ -2574,7 +2598,7 @@ int PylonCameraImpl<CameraTraitT>::getLightSourcePreset()
             else if (cam_->BslLightSourcePreset.GetValue() == Basler_UniversalCameraParams::BslLightSourcePresetEnums::BslLightSourcePreset_Daylight6500K)
             {
                 return 2; // Daylight6500K
-            } 
+            }
             else 
             {
                 return -3; // Unkonwn


### PR DESCRIPTION
## やること

カメラノード起動時にlight source presetをLED 6500Kに設定し直す

- [x] LightSourcePresetの選択肢に MicroscopeLED4500K,5500K,6000K を追加できていること（公式のコード編集が必須）
- [x] CameraInitializerからset_light_source_presetサービスを呼び出し，MicroscopeLED6500Kを選択していること


## 参考資料
